### PR TITLE
Mimic rawv2 data, tag macs AEDDDDDDDDXX

### DIFF
--- a/tests/loadtest/gatewayTest.js
+++ b/tests/loadtest/gatewayTest.js
@@ -74,13 +74,14 @@ const options = {
 
 		const request = client(options, callback);
 		request.write(options.body);
-        /* console.log(options.body); */
+
 		return request;
 	}
 };
 
 const mergedOptions = Object.assign({}, options, argv);
 console.log(mergedOptions);
+
 loadtest.loadTest(mergedOptions, (error, results) => {
 	if (error) {
 		return console.error('Got an error: %s', error);


### PR DESCRIPTION
e.g.
```
{
    "data": {
        "coordinates": "",
        "timestamp": 1597854777419,
        "gwmac": "240ac4e32eb4",
        "tags": {
            "AEDDDDDDDD15": {
                "rssi": -76,
                "timestamp": 1597854777419,
                "data": "0201041BFF9904051E0A17DB0FE94E92F1DE7718C990DA4E1997AD2AFADD0EF9"
            },
            "AEDDDDDDDD2E": {
                "rssi": -76,
                "timestamp": 1597854777419,
                "data": "0201041BFF990405DA6520ABDDED631E5A1CDF7C3AE1009FDB984026014DF3E5"
            },
            "AEDDDDDDDD30": {
                "rssi": -76,
                "timestamp": 1597854777419,
                "data": "0201041BFF990405AA4EB8BAFB077A23496242915F14610E100B66FEB440C33D"
            },
            "AEDDDDDDDD5D": {
                "rssi": -76,
                "timestamp": 1597854777419,
                "data": "0201041BFF99040517F347C38B1B4A668E50A62583755A9ACE0A25FD88BCC573"
            }
        }
    }
}
``` 
Last 6 bytes of data should match the Mac address, if some backend actually parses the Mac from payload that needs to be fixed. Otherwise data is valid Ruuvi data format 5 data, although values can be unreasonable. 